### PR TITLE
Enhancement: Simplify ModuleView view helper by simplifying Module service

### DIFF
--- a/module/User/view/zfc-user/user/index.phtml
+++ b/module/User/view/zfc-user/user/index.phtml
@@ -22,7 +22,7 @@
         <br />
         <div class="tab-content">
             <div class="tab-pane active" id="modules">
-            <?php /* @var ZfModule\Entity\Module[] $modules */ ?>
+            <?php /* @var stdClass[] $modules */ ?>
             <?php if (!count($modules)): ?>
                 <div class="alert alert-block">No modules have been submitted yet</div>
             <?php else: ?>

--- a/module/ZfModule/src/ZfModule/Service/Module.php
+++ b/module/ZfModule/src/ZfModule/Service/Module.php
@@ -112,7 +112,7 @@ class Module extends EventProvider
     }
 
     /**
-     * @return Entity\Module[]
+     * @return stdClass[]
      */
     public function currentUserModules()
     {
@@ -122,25 +122,21 @@ class Module extends EventProvider
             'per_page' => 100,
         ]);
 
-        $modules = [];
-
-        foreach ($repositoryCollection as $repository) {
+        return array_filter(iterator_to_array($repositoryCollection), function ($repository) {
             if (true === $repository->fork) {
-                continue;
+                return false;
             }
 
             if (false === $repository->permissions->push) {
-                continue;
+                return false;
             }
 
             $module = $this->moduleMapper->findByName($repository->name);
             if (!($module instanceof Entity\Module)) {
-                continue;
+                return false;
             }
 
-            array_push($modules, $module);
-        }
-
-        return $modules;
+            return true;
+        });
     }
 }

--- a/module/ZfModule/src/ZfModule/Service/Module.php
+++ b/module/ZfModule/src/ZfModule/Service/Module.php
@@ -131,8 +131,7 @@ class Module extends EventProvider
                 return false;
             }
 
-            $module = $this->moduleMapper->findByName($repository->name);
-            if (!($module instanceof Entity\Module)) {
+            if (null === $this->moduleMapper->findByName($repository->name)) {
                 return false;
             }
 

--- a/module/ZfModule/src/ZfModule/View/Helper/ModuleView.php
+++ b/module/ZfModule/src/ZfModule/View/Helper/ModuleView.php
@@ -2,10 +2,8 @@
 
 namespace ZfModule\View\Helper;
 
-use InvalidArgumentException;
 use stdClass;
 use Zend\View\Helper\AbstractHelper;
-use ZfModule\Entity;
 
 class ModuleView extends AbstractHelper
 {
@@ -13,53 +11,20 @@ class ModuleView extends AbstractHelper
     const BUTTON_REMOVE = 'remove';
 
     /**
-     * @param Entity\Module|stdClass $module
+     * @param stdClass $module
      * @param string $button
      * @return string
      */
     public function __invoke($module, $button = 'submit')
     {
-        $values = $this->fetchValues($module);
-
-        $values += [
+        return $this->getView()->render('zf-module/helper/module-view.phtml', [
+            'owner' => $module->owner->login,
+            'name' => $module->name,
+            'createdAt' => $module->created_at,
+            'url' => $module->html_url,
+            'photoUrl' => $module->owner->avatar_url,
+            'description' => $module->description,
             'button' => $button,
-        ];
-
-        return $this->getView()->render('zf-module/helper/module-view.phtml', $values);
-    }
-
-    /**
-     * @param stdClass|Entity\Module$module
-     * @return array
-     */
-    private function fetchValues($module)
-    {
-        if ((!$module instanceof stdClass) && !($module instanceof Entity\Module)) {
-            throw new InvalidArgumentException(sprintf(
-                'Parameter "%s" needs to be specified as %s',
-                '$module',
-                'an instance of stdClass or ZfModule\Entity\Module'
-            ));
-        }
-
-        if ($module instanceof stdClass) {
-            return [
-                'owner' => $module->owner->login,
-                'name' => $module->name,
-                'createdAt' => $module->created_at,
-                'url' => $module->html_url,
-                'photoUrl' => $module->owner->avatar_url,
-                'description' => $module->description,
-            ];
-        }
-
-        return [
-            'owner' => $module->getOwner(),
-            'name' => $module->getName(),
-            'createdAt' => $module->getCreatedAt(),
-            'url' => $module->getUrl(),
-            'photoUrl' => $module->getPhotoUrl(),
-            'description' => $module->getDescription(),
-        ];
+        ]);
     }
 }

--- a/module/ZfModule/test/ZfModuleTest/Service/ModuleTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Service/ModuleTest.php
@@ -89,11 +89,11 @@ class ModuleTest extends PHPUnit_Framework_TestCase
         $repository->permissions->push = true;
         $repository->name = $name;
 
-        $module = $this->getMockBuilder(Entity\Module::class)->getMock();
-
-        $modules = [
-            $module,
+        $repositories = [
+            $repository,
         ];
+
+        $module = $this->getMockBuilder(Entity\Module::class)->getMock();
 
         $moduleMapper = $this->getMockBuilder(Mapper\Module::class)->getMock();
 
@@ -130,7 +130,7 @@ class ModuleTest extends PHPUnit_Framework_TestCase
             $githubClient
         );
 
-        $this->assertSame($modules, $service->currentUserModules());
+        $this->assertSame($repositories, $service->currentUserModules());
     }
 
     public function testListUserModulesDoesNotLookupModulesFromApiWhereUserHasNoPushPrivilege()

--- a/module/ZfModule/test/ZfModuleTest/View/Helper/ModuleViewTest.php
+++ b/module/ZfModule/test/ZfModuleTest/View/Helper/ModuleViewTest.php
@@ -5,7 +5,6 @@ namespace ZfModuleTest\View\Helper;
 use PHPUnit_Framework_TestCase;
 use stdClass;
 use Zend\View;
-use ZfModule\Entity;
 use ZfModule\View\Helper;
 
 class ModuleViewTest extends PHPUnit_Framework_TestCase
@@ -39,53 +38,9 @@ class ModuleViewTest extends PHPUnit_Framework_TestCase
         $helper($repository);
     }
 
-    public function testInvokeHandlesModule()
-    {
-        $module = $this->module();
-
-        $view = $this->getMockForAbstractClass(View\Renderer\RendererInterface::class);
-
-        $view
-            ->expects($this->once())
-            ->method('render')
-            ->with(
-                $this->equalTo('zf-module/helper/module-view.phtml'),
-                $this->equalTo([
-                    'owner' => $module->getOwner(),
-                    'name' => $module->getName(),
-                    'createdAt' => $module->getCreatedAt(),
-                    'url' => $module->getUrl(),
-                    'photoUrl' => $module->getPhotoUrl(),
-                    'description' => $module->getDescription(),
-                    'button' => 'submit',
-                ])
-            )
-        ;
-
-        $helper = new Helper\ModuleView();
-        $helper->setView($view);
-
-        $helper($module);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testInvokeDoesNotHandleAnythingElse()
-    {
-        $module = 'foo';
-
-        $view = $this->getMockForAbstractClass(View\Renderer\RendererInterface::class);
-
-        $helper = new Helper\ModuleView();
-        $helper->setView($view);
-
-        $helper($module);
-    }
-
     public function testInvokeAllowsSpecifyingButtonType()
     {
-        $module = $this->module();
+        $repository = $this->repository();
         $button = 'baz';
 
         $view = $this->getMockForAbstractClass(View\Renderer\RendererInterface::class);
@@ -107,7 +62,7 @@ class ModuleViewTest extends PHPUnit_Framework_TestCase
         $helper = new Helper\ModuleView();
         $helper->setView($view);
 
-        $helper($module, $button);
+        $helper($repository, $button);
     }
 
     /**
@@ -127,22 +82,5 @@ class ModuleViewTest extends PHPUnit_Framework_TestCase
         $repository->owner->avatar_url = 'http://www.example.org/img/suzie.gif';
 
         return $repository;
-    }
-
-    /**
-     * @return Entity\Module
-     */
-    private function module()
-    {
-        $module = new Entity\Module();
-
-        $module->setName('foo');
-        $module->setDescription('blah blah');
-        $module->setCreatedAt('1970-01-01 00:00:00');
-        $module->setUrl('http://www.example.org');
-        $module->setOwner('suzie');
-        $module->setPhotoUrl('http://www.example.org/img/suzie.gif');
-
-        return $module;
     }
 }


### PR DESCRIPTION
This PR

* [x] simplifies the `ZfModule\Service\Module` by only filtering the `RepositoryCollection` and returning an array of `stdClass` instead of an array of `ZfModule\Entity\Module
* [x] simplifies the `ModuleView` helper as there's only one use case now, rendering an instance of `stdClass`